### PR TITLE
Updated _fixed_process to _physics_process for Godot v3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ sm.transition("patrol")
 
 ### State Machine Callbacks
 
-The state manager exposes callback methods for `_process(delta)`, `_fixed_process(delta)`, and `_input(event)`. Calls to these methods are proxied down to the current state's method if it has implemented them.
+The state manager exposes callback methods for `_process(delta)`, `_physics_process(delta)`, and `_input(event)`. Calls to these methods are proxied down to the current state's method if it has implemented them.
 
 ```gdscript
 # State machine callbacks which are proxied down to the current state object
-sm._fixed_process(delta)
+sm._physics_process(delta)
 sm._process(delta)
 sm._input(event)
 ```
@@ -163,14 +163,14 @@ var player = state.get_target()
 
 ### State Callbacks
 
-A state class can implement callbacks for `_process(delta)`, `_fixed_process(delta)`, `_input(event)`, `_on_enter_state()`, and `_on_leave_state()`.
+A state class can implement callbacks for `_process(delta)`, `_physics_process(delta)`, `_input(event)`, `_on_enter_state()`, and `_on_leave_state()`.
 
 ```gdscript
 extends "state.gd"
 
 var memory = 0
 
-func _fixed_process(delta):
+func _physics_process(delta):
 	scan_for_enemy(delta)
 	move_to_random(delta)
 

--- a/addons/godot-finite-state-machine/state_machine.gd
+++ b/addons/godot-finite-state-machine/state_machine.gd
@@ -154,11 +154,11 @@ func _process(delta):
 	"""
 	if _current_state.has_method("_process"): _current_state._process(delta)
 
-func _fixed_process(delta):
+func _physics_process(delta):
 	"""
-	Callback to handle _fixed_process(). Must be called manually by code
+	Callback to handle _physics_process(). Must be called manually by code
 	"""
-	if _current_state.has_method("_fixed_process"): _current_state._fixed_process(delta)
+	if _current_state.has_method("_physics_process"): _current_state._physics_process(delta)
 
 func _input(event):
 	"""
@@ -187,5 +187,5 @@ class DefaultState extends State:
 	Default state class to implement null object pattern for the state machine's current state
 	"""
 	func _process(delta): print("Unimplemented _process(delta)")
-	func _fixed_process(delta): print("Unimplemented _fixed_process(delta)")
+	func _physics_process(delta): print("Unimplemented _physics_process(delta)")
 	func _input(event): print("Unimplemented _input(event)")


### PR DESCRIPTION
_fixed_process on the Node class was renamed to _physics_process for Godot 3.0.  I've renamed it accordingly in this repo so that it works for 3.0+.