### PR TITLE
Solved cyclic references.

### DIFF
--- a/addons/fsm/StateMachine.gd
+++ b/addons/fsm/StateMachine.gd
@@ -92,7 +92,7 @@ func set_state(state_id: String, state: State) -> void:
 	states[state_id] = state
 
 	state.id = state_id
-	state.state_machine = self
+	state.state_machine = weakref(self)
 
 	if target:
 		state.set_target(target)
@@ -199,7 +199,7 @@ class State extends Resource:
 	var target
 
 	# Reference to state machine
-	var state_machine: StateMachine
+	var state_machine: WeakRef
 
 	var process_enabled: bool = true
 	var physics_process_enabled: bool = true

--- a/example/src/Enemy/AttackState.gd
+++ b/example/src/Enemy/AttackState.gd
@@ -8,7 +8,7 @@ func _init().():
 
 func _process(_delta: float) -> void:
 	if not target.has_enemies():
-		state_machine.transition("patrol")
+		state_machine.get_ref().transition("patrol")
 		return
 
 	target.attack_enemies()

--- a/example/src/Enemy/IdleState.gd
+++ b/example/src/Enemy/IdleState.gd
@@ -9,7 +9,7 @@ func _init().():
 func _process(_delta: float) -> void:
 	# Start patrolling when the player gets closer to us
 	if target.should_patrol():
-		state_machine.transition("patrol")
+		state_machine.get_ref().transition("patrol")
 
 func _on_enter_state() -> void:
 	target.say("I feel at peace.")

--- a/example/src/Enemy/PatrolState.gd
+++ b/example/src/Enemy/PatrolState.gd
@@ -23,11 +23,11 @@ func _process(_delta: float) -> void:
 
 	# We're close to the target, let's attack them
 	if target.has_enemies():
-		state_machine.transition("attack")
+		state_machine.get_ref().transition("attack")
 
 	# We're far from the player, stop patrolling
 	elif not target.should_patrol():
-		state_machine.transition("idle")
+		state_machine.get_ref().transition("idle")
 
 func check_for_new_patrol_direction() -> void:
 	"""


### PR DESCRIPTION
Hi, I made a little modifications by changing the `StateMachine.State.state_machine` attribute a `WeakRef` to `StateMachine` type, in order to avoid cyclic references. Indeed direct reference to `StateMachine` gives rise to a series of leaked instances and orphan resources (that can be detected when the program exits using the --verbose option of the godot engine).

Anyway, your fsm was helpful in my game project. Thank you